### PR TITLE
Github Actions - CI Release

### DIFF
--- a/.github/workflows/CI_Release.yml
+++ b/.github/workflows/CI_Release.yml
@@ -1,0 +1,88 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        java-version: '8'
+        distribution: 'adopt'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+ 
+    - name: Get version
+      run: echo "version=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) " >> $GITHUB_ENV
+ 
+    - name: Build with Maven
+      run: mvn -DskipTests -B package --file pom.xml
+        
+    - name: Clean Install
+      run: |
+        export REPLICADB_RELEASE_VERSION=${{ env.version }}
+        echo ${REPLICADB_RELEASE_VERSION}  
+        mvn clean install -Dmaven.javadoc.skip=true -DskipTests -B -V -P release 
+        cp ./target/ReplicaDB-*.jar . 
+        mkdir lib
+        echo ${REPLICADB_RELEASE_VERSION} 
+        cp ./target/lib/* ./lib 
+        tar -zcvf ReplicaDB-v${REPLICADB_RELEASE_VERSION}.tar.gz ReplicaDB-*.jar README.md lib conf bin LICENSE 
+        zip -r -X ReplicaDB-v${REPLICADB_RELEASE_VERSION}.zip ReplicaDB-*.jar README.md lib conf bin LICENSE 
+        ls -lahtr
+        
+    
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: ${{ env.version }}
+        prerelease: false
+        files: |
+          ReplicaDB-v*.zip
+          ReplicaDB-v*.tar.gz
+
+    -   name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        
+    -   name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+    
+    -   name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+    
+    -   name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: osalvador/replicadb:${{ env.version }}, osalvador/replicadb:latest
+
+    -   name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Containerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: osalvador/replicadb:ubi8-${{ env.version }}, osalvador/replicadb:ubi8-latest
+    
+
+
+    
+


### PR DESCRIPTION
Good afternoon Oscar,

here I am, starting migration from travis to GitHub Actions!

I think You need to add 

- secrets.DOCKERHUB_USERNAME 
- secrets.DOCKERHUB_TOKEN

inside your repo (https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository)

My CI_Release.yml is pretty simple: I am not a Java Expert and for this part I check point to point your travis file.

After that I created tagged release on Github and I called DockerHub for both Dockerfile and Containerfile, tagging the images (i added a simple prefix ubi8- for the containerfile release.

If someone push on GitHub a release with the same tag, the Github Release will be updated and also the DockerHub images.