### PR TITLE
[conf/_replicadb.conf] fix typos

### DIFF
--- a/conf/_replicadb.conf
+++ b/conf/_replicadb.conf
@@ -17,7 +17,7 @@ fetch.size=100
 # quoted.identifiers=false
 # verbose=false
 
-############################# Soruce Options #############################
+############################# Source Options #############################
 source.connect=
 source.user=
 source.password=
@@ -28,7 +28,7 @@ source.where=
 source.query=
 
 ## Optional extra JDBC parameters
-# source.connect.parameter.[prameter_name]=parameter_value
+# source.connect.parameter.[parameter_name]=parameter_value
 
 ############################# Sink Options #############################
 sink.connect=
@@ -38,7 +38,7 @@ sink.table=
 sink.columns=
 
 ## Optional extra JDBC parameters
-# sink.connect.parameter.[prameter_name]=parameter_value
+# sink.connect.parameter.[parameter_name]=parameter_value
 
 ## Staging options for incremental mode
 # sink.staging.table=


### PR DESCRIPTION
This commit fixes some typos in `conf/_replicadb.conf`.