### PR TITLE
Add log level handling as verbose parameter

### DIFF
--- a/src/main/java/org/replicadb/ReplicaDB.java
+++ b/src/main/java/org/replicadb/ReplicaDB.java
@@ -62,11 +62,9 @@ public class ReplicaDB {
 
         LOG.info("Running ReplicaDB version: " + options.getVersion());
 
-        if (options.isVerbose()) {
-            setLogToDebugMode();
-            LOG.info("Setting verbose mode");
-            LOG.debug(options.toString());
-        }
+        ReplicaDB.setLogToMode(options.getVerboseLevel());
+        LOG.info("Setting verbose mode " + options.getVerboseLevel());
+        LOG.debug(options.toString());
 
         if (!options.isHelp() && !options.isVersion()) {
             // Sentry
@@ -163,14 +161,12 @@ public class ReplicaDB {
     }
 
 
-    private static void setLogToDebugMode() {
-
+    private static void setLogToMode(Level level) {
         LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
         Configuration config = ctx.getConfiguration();
         LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
-        loggerConfig.setLevel(Level.valueOf("DEBUG"));
+        loggerConfig.setLevel(level);
         ctx.updateLoggers();  // This causes all Loggers to refetch information from their LoggerConfi
-
     }
 
 

--- a/src/main/java/org/replicadb/cli/ToolOptions.java
+++ b/src/main/java/org/replicadb/cli/ToolOptions.java
@@ -1,6 +1,7 @@
 package org.replicadb.cli;
 
 import org.apache.commons.cli.*;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -43,7 +44,7 @@ public class ToolOptions {
     private int bandwidthThrottling = 0;
     private Boolean help = false;
     private Boolean version = false;
-    private Boolean verbose = false;
+    private Level verboseLevel = Level.INFO;
     private Boolean quotedIdentifiers = false;
     private String optionsFile;
 
@@ -335,7 +336,7 @@ public class ToolOptions {
             }
 
             //get & set Options
-            if (line.hasOption("verbose")) setVerbose(true);
+            if (line.hasOption("verbose")) handleVerboseLevelArgument(line.getOptionValue("verbose"));
             if (line.hasOption("sink-disable-index")) setSinkDisableIndexNotNull(true);
             if (line.hasOption("sink-disable-escape")) setSinkDisableEscapeNotNull(true);
             if (line.hasOption("sink-disable-truncate")) setSinkDisableTruncateNotNull(true);
@@ -372,6 +373,22 @@ public class ToolOptions {
 
     }
 
+    private void handleVerboseLevelArgument(String verboseLevel) {
+        if (verboseLevel == null || verboseLevel.isEmpty()) {
+            setVerboseLevel(Level.INFO);
+            return;
+        } else if (Boolean.parseBoolean(verboseLevel)) {
+            setVerboseLevel(Level.DEBUG);
+            return;
+        }
+
+        try {
+            Level argumentLevel = Level.valueOf(verboseLevel);
+            setVerboseLevel(argumentLevel);
+        } catch (IllegalArgumentException e) {
+            setVerboseLevel(Level.INFO);
+        }
+    }
 
     private void printHelp() {
         String header = "\nArguments: \n";
@@ -433,7 +450,7 @@ public class ToolOptions {
         Properties prop = of.getProperties();
         setSinkAnalyze(Boolean.parseBoolean(prop.getProperty("sink.analyze")));
 
-        setVerbose(Boolean.parseBoolean(prop.getProperty("verbose")));
+        handleVerboseLevelArgument(prop.getProperty("verbose"));
         setMode(prop.getProperty("mode"));
 
         setSinkColumns(prop.getProperty("sink.columns"));
@@ -671,17 +688,12 @@ public class ToolOptions {
     }
 
 
-    public Boolean isVerbose() {
-        return verbose;
+    public Level getVerboseLevel() {
+        return verboseLevel;
     }
 
-    public void setVerbose(Boolean verbose) {
-        this.verbose = verbose;
-    }
-
-    public void setVerboseNotNull(Boolean verbose) {
-        if (verbose != null)
-            this.verbose = verbose;
+    public void setVerboseLevel(Level verboseLevel) {
+        this.verboseLevel = verboseLevel;
     }
 
     public String getOptionsFile() {
@@ -872,7 +884,7 @@ public class ToolOptions {
                 ",\n\tfetchSize=" + fetchSize +
                 ",\n\thelp=" + help +
                 ",\n\tversion=" + version +
-                ",\n\tverbose=" + verbose +
+                ",\n\tverbose=" + verboseLevel +
                 ",\n\toptionsFile='" + optionsFile + '\'' +
                 ",\n\tmode='" + mode + '\'' +
                 ",\n\tsentryDsn='" + sentryDsn + '\'' +


### PR DESCRIPTION
I had a hard time debugging an issue, I needed TRACE log level whereas verbose argument only allow to see DEBUG log level.

So I did some changes in order to allow to pass a log level parameter to verbose, in addition to a boolean.