### PR TITLE
Update to support BIT data type in MySQL/MariaDB tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<h3>What does this fork add?</h3>
+<p>This fork fixes the issue with the BIT data type being copied incorrectly between MySQL or MariaDB instances by treating them as binary variables during the insertion process</p>
+
 <img src="https://img.shields.io/github/license/osalvador/replicadb?style=for-the-badge" alt="License"> <img src="https://img.shields.io/github/v/release/osalvador/replicadb?style=for-the-badge"  alt="Last Version">
 <img src="https://img.shields.io/docker/pulls/osalvador/replicadb.svg?style=for-the-badge&logo=docker" alt="Docker Pull">
 <img src="https://img.shields.io/github/downloads/osalvador/replicadb/total?style=for-the-badge&logo=github" alt="Github Downloads">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-<h3>What does this fork add?</h3>
-<p>This fork fixes the issue with the BIT data type being copied incorrectly between MySQL or MariaDB instances by treating them as binary variables during the insertion process</p>
-
 <img src="https://img.shields.io/github/license/osalvador/replicadb?style=for-the-badge" alt="License"> <img src="https://img.shields.io/github/v/release/osalvador/replicadb?style=for-the-badge"  alt="Last Version">
 <img src="https://img.shields.io/docker/pulls/osalvador/replicadb.svg?style=for-the-badge&logo=docker" alt="Docker Pull">
 <img src="https://img.shields.io/github/downloads/osalvador/replicadb/total?style=for-the-badge&logo=github" alt="Github Downloads">

--- a/src/main/java/org/replicadb/manager/MySQLManager.java
+++ b/src/main/java/org/replicadb/manager/MySQLManager.java
@@ -185,6 +185,7 @@ public class MySQLManager extends SqlManager {
          String[] columns = allColumns.split(",");
          for (int i = 0; i < columns.length; i++) {
             switch (rsmd.getColumnType(i + 1)) {
+               case Types.BIT:
                case Types.BINARY:
                case Types.BLOB:
                case Types.VARBINARY:
@@ -204,6 +205,7 @@ public class MySQLManager extends SqlManager {
          String setPrefix = " SET ";
          for (int i = 0; i < columns.length; i++) {
             switch (rsmd.getColumnType(i + 1)) {
+               case Types.BIT:
                case Types.BINARY:
                case Types.BLOB:
                case Types.VARBINARY:


### PR DESCRIPTION
Added BIT support for the aforementioned databases - fixes the issue wherein data in BIT fields would be set to "true" regardless of source data