### PR TITLE
bump mssql driver version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>7.2.2.jre8</version>
+            <version>11.2.3.jre8</version>
         </dependency>
 
         <!-- Amazon S3 -->


### PR DESCRIPTION
I had to bump mssql driver version in order to fix an issue explained here https://github.com/microsoft/mssql-jdbc/issues/1486

Unfortunately, I could not run the maven tests, several images being incompatible with my environnement (Mac with M1 chip)