### PR TITLE
Replicar campos CLOB - Oracle to Oracle

### DIFF
--- a/src/main/java/org/replicadb/manager/OracleManager.java
+++ b/src/main/java/org/replicadb/manager/OracleManager.java
@@ -10,6 +10,7 @@ import org.replicadb.manager.util.BandwidthThrottling;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
 import java.sql.*;
 import java.util.Arrays;
 
@@ -176,8 +177,13 @@ public class OracleManager extends SqlManager {
                             break;
                         case Types.CLOB:
                             Clob clobData = resultSet.getClob(i);
-                            ps.setClob(i, clobData);
-                            if (clobData != null) clobData.free();
+                            //ps.setClob(i, clobData);
+                            if (clobData != null) 
+                            {                            	
+                            	//Se establece los datos del campo CLOB como un objeto java.io.Reader
+                            	ps.setClob(i, clobData.getCharacterStream());
+                            	clobData.free();
+                            }
                             break;
                         case Types.BOOLEAN:
                             ps.setBoolean(i, resultSet.getBoolean(i));


### PR DESCRIPTION
Al tratar de ejecutar la replica de una tabla con campos CLOB de Oracle - Oracle, se presenta una excepción, por lo que se procedió a obtener los datos del campo CLOB de la tabla origen como un objeto Reader (stream of characters) y este valor establecerlo en el campo de la tabla destino, consiguiendo que el resultado sea exitoso.