### PR TITLE
Ajustar persistencia de campos CLOB cuando existen valores null

### DIFF
--- a/src/main/java/org/replicadb/manager/OracleManager.java
+++ b/src/main/java/org/replicadb/manager/OracleManager.java
@@ -177,13 +177,14 @@ public class OracleManager extends SqlManager {
                             break;
                         case Types.CLOB:
                             Clob clobData = resultSet.getClob(i);
-                            //ps.setClob(i, clobData);
                             if (clobData != null) 
                             {                            	
                             	//Se establece los datos del campo CLOB como un objeto java.io.Reader
                             	ps.setClob(i, clobData.getCharacterStream());
                             	clobData.free();
                             }
+                            else//si el dato es null en el campo CLOB, se setea directamente el clobData
+                            	ps.setClob(i, clobData);
                             break;
                         case Types.BOOLEAN:
                             ps.setBoolean(i, resultSet.getBoolean(i));


### PR DESCRIPTION
Ajustar persistencia de campos CLOB cuando existen valores null en los campos CLOB. Solamente estaba funcionando cuando existían valores en todos los registros de tipo CLOB